### PR TITLE
Refactor: Enhance useGetUser hook with error handling

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -11,7 +11,7 @@ export function useGetUser(option?: { enabled: boolean }) {
 
   const shouldFetch = option?.enabled ?? !!accessToken;
 
-  const { data, isLoading, refetch } = useQuery<IUserItem>({
+  const { data, isLoading, refetch, isError, error } = useQuery<IUserItem>({
     ...option,
     queryKey: queryKeys.user.root,
     queryFn: () => fetcher(endpoints.user.profile),
@@ -29,7 +29,9 @@ export function useGetUser(option?: { enabled: boolean }) {
       profileData: data,
       profileRefetch: refetch,
       profileLoading: isLoading,
+      profileError: error,
+      isProfileError: isError,
     }),
-    [data, isLoading, refetch]
+    [data, isLoading, refetch, error, isError]
   );
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -15,9 +15,10 @@ export default function SideBar() {
   const [collapsed, setCollapsed] = useState(false);
   const logout = useAuthStore((state) => state.logout);
   const accessToken = useAuthStore((state) => state.accessToken);
-  const { profileData, profileLoading } = useGetUser({
-    enabled: !!accessToken,
-  });
+  const { profileData, profileLoading, isProfileError, profileError } =
+    useGetUser({
+      enabled: !!accessToken,
+    });
 
   const handleLogout = () => {
     try {
@@ -95,6 +96,8 @@ export default function SideBar() {
               <div className="flex flex-col items-start font-display overflow-hidden">
                 {profileLoading ? (
                   <div className="text-sm text-neutral-500">Loading...</div>
+                ) : isProfileError ? (
+                  <div className="text-sm text-red-500">Error loading profile</div>
                 ) : (
                   <>
                     <h1 className="text-neutral-800 font-semibold truncate max-w-[100px]">


### PR DESCRIPTION
- Modified the `useGetUser` hook in `src/api/user.ts` to return `isError` and `error` states from `useQuery`.
- Updated `src/components/layout/sidebar.tsx` to utilize these new error states, displaying an error message if fetching user profile data fails.